### PR TITLE
docs: add stickyburp project

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -180,6 +180,7 @@ Profile Summary:
 Some notable projects I've worked on:
 
 - <a href="https://github.com/dreadnode/burpference" target="_blank">burpference</a>: A web application for identifying and reporting security vulnerabilities in Burp Suite.
+- <a href="https://github.com/GangGreenTemperTatum/stickyburp" target="_blank">stickyburp</a>: A Burp Suite extension written in Kotlin that enables persistent sticky session handling in web application testing.
 - <a href="https://github.com/dreadnode/robopages" target="_blank">Robopages</a>: Robopages are YAML based files for describing tools to large language models (LLMs). They simplify the process of defining and using external tools in LLM-powered applications. By leveraging the robopages-cli function calling server, developers can avoid the tedious task of manually writing JSON declarations for each tool.
 - <a href="https://github.com/GangGreenTemperTatum/DOMspy" target="_blank">DOMspy</a>: A typescript-based extension for identifying and reporting security vulnerabilities in web applications.
 - <a href="https://github.com/Addepar/RedFlag" target="_blank">Redflag:</a>: RedFlag leverages AI to determine high-risk code changes. Run it in batch mode to scope manual security testing of release candidates, or run it in your CI pipelines to flag PRs and add the appropriate reviewers.


### PR DESCRIPTION
## AI-Generated Summary

### PR Summary

#### Overview of Changes
Ahoy! We've hoisted a new flag on our JavaScript ship, bringing aboard a shiny addition to our treasure trove of projects displayed. A new project, dubbed "stickyburp," has been anchored to our list, showcasing a Burp Suite extension crafted in the fine programming language of Kotlin. This extension is a mighty tool for web application testers, giving them the power to manage sticky sessions with ease and agility.

#### Key Modifications
1. **Addition of stickyburp Project**: Added a new entry under the "Some notable projects I've worked on" section, introducing "stickyburp" with a link and a brief description. This extension is designed for persistent sticky session handling during web application testing, making it a valuable asset for sailors of the cyber seas.

#### Potential Impact
- Enhancing the visibility of new and innovative tools within the web application testing community.
- Providing quick access to the "stickyburp" project could increase its usage and, consequently, feedback from the community, potentially leading to further improvements in sticky session management.
- Broadening the scope of projects listed on the page might attract more contributors and collaborators, fostering a more vibrant and skilled crew to tackle the challenges of web security.

---

This summary was generated with ❤️ by ads @ [rigging](https://rigging.dreadnode.io/)
