### PR TITLE
chore: update speaking refs to new gh page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/css/style.css
+++ b/css/style.css
@@ -99,3 +99,31 @@ a:hover {
     white-space: pre;
     margin: 10px 0;
 }
+
+/* Tip Container Styles */
+.tip-container {
+    position: fixed;
+    bottom: 20px;
+    left: 0;
+    right: 0;
+    text-align: center;
+    z-index: 100;
+}
+
+.tip-text {
+    display: inline-block;
+    padding: 8px 16px;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: #0f0;
+    border-radius: 4px;
+    font-family: monospace;
+    border: 1px solid #0f0;
+    box-shadow: 0 0 10px rgba(0, 255, 0, 0.3);
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0% { opacity: 0.7; }
+    50% { opacity: 1; }
+    100% { opacity: 0.7; }
+}

--- a/index.html
+++ b/index.html
@@ -18,6 +18,9 @@
     <div class="terminal-container">
         <div id="terminal"></div>
     </div>
+    <div class="tip-container">
+        <p class="tip-text">Tip: Type 'speaking' into the terminal to head on over to my thought-leadership portfolio</p>
+    </div>
     <script src="script/main.js"></script>
 </body>
 </html>

--- a/script/main.js
+++ b/script/main.js
@@ -15,7 +15,7 @@ class Terminal {
             linkedin: () => window.open('https://linkedin.com/in/adamdawson0', '_blank'),
             projects: () => this.showProjects(),
             skills: () => this.showSkills(),
-            speaking: () => window.open('https://github.com/GangGreenTemperTatum/speaking', '_blank'),
+            speaking: () => window.open('https://ganggreentempertatum.github.io/speaking/', '_blank'),
             thoughtwork: () => this.showThoughtwork(),
         };
 
@@ -32,15 +32,14 @@ class Terminal {
         const welcome = `
 <div class="welcome-container">
     <pre class="ascii-art">
-╔════════════════════════════════════════════════════════════╗
-║                            ads                             ║
-║                  Staff AI Security Researcher              ║
-║                                                            ║
-║               Type 'help' for available commands           ║
-║                  GitHub: @GangGreenTemperTatum             ║
-╚════════════════════════════════════════════════════════════╝
+╔═══════════════════════════════════════════════════╗
+║                        ads                        ║
+║            Staff AI Security Researcher           ║
+║                                                  ║
+║        Type 'help' for available commands        ║
+║   GitHub: <a href="https://github.com/GangGreenTemperTatum" target="_blank">@GangGreenTemperTatum</a>          ║
+╚═══════════════════════════════════════════════════╝
     </pre>
-    <div><a href="https://github.com/GangGreenTemperTatum" target="_blank">Visit my GitHub profile</a></div>
     <img src="assets/nyan_cat_gif.gif" alt="Welcome Animation" class="welcome-gif" style="width: 400px;"/>
     <br>
     <br>


### PR DESCRIPTION
## AI-Generated Summary

- Added a `.gitignore` file to exclude `.DS_Store` files from version control.
- Introduced a new tip container in `index.html` that provides a suggestion to users:
  - "Tip: Type 'speaking' into the terminal to head on over to my thought-leadership portfolio"
- Enhanced the `style.css` with styles for the new tip container, including:
  - Fixed position at the bottom with centered text.
  - Styling for the tip text, including background color, border, rounded corners, and a pulsing animation.
- Updated the `main.js` file to change the link for the `speaking` command:
  - Updated from GitHub link to the new GitHub Pages URL for the speaking portfolio.
- Modified the welcome message in `main.js` to include:
  - Ascii art layout simplification.
  - Made the GitHub link clickable.

These changes improve user experience by providing guidance and ensuring that links are updated and accessible.

---

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
